### PR TITLE
feat: カテゴリごとのメンバー負担割合設定機能を追加

### DIFF
--- a/src/main/database.js
+++ b/src/main/database.js
@@ -65,6 +65,18 @@ function createTables() {
       FOREIGN KEY (paid_by) REFERENCES members(id)
     )
   `)
+
+  db.run(`
+    CREATE TABLE IF NOT EXISTS category_burden_ratios (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      category_id INTEGER NOT NULL,
+      member_id INTEGER NOT NULL,
+      ratio INTEGER NOT NULL DEFAULT 1,
+      UNIQUE(category_id, member_id),
+      FOREIGN KEY (category_id) REFERENCES categories(id),
+      FOREIGN KEY (member_id) REFERENCES members(id)
+    )
+  `)
 }
 
 function insertDefaultCategories() {
@@ -100,8 +112,16 @@ export function getAllMembers() {
 
 export function createMember(name) {
   db.run('INSERT INTO members (name) VALUES (?)', [name])
+  const newMember = toObjects(db.exec('SELECT * FROM members WHERE id = last_insert_rowid()'))[0]
+  const categories = getAllCategories()
+  categories.forEach((c) => {
+    db.run(
+      'INSERT OR IGNORE INTO category_burden_ratios (category_id, member_id, ratio) VALUES (?, ?, 1)',
+      [c.id, newMember.id]
+    )
+  })
   saveDb()
-  return toObjects(db.exec('SELECT * FROM members WHERE id = last_insert_rowid()'))[0]
+  return newMember
 }
 
 export function updateMember(id, name) {
@@ -110,6 +130,7 @@ export function updateMember(id, name) {
 }
 
 export function deleteMember(id) {
+  db.run('DELETE FROM category_burden_ratios WHERE member_id = ?', [id])
   db.run('DELETE FROM members WHERE id = ?', [id])
   saveDb()
 }
@@ -122,8 +143,16 @@ export function getAllCategories() {
 
 export function createCategory(name) {
   db.run('INSERT INTO categories (name) VALUES (?)', [name])
+  const newCategory = toObjects(db.exec('SELECT * FROM categories WHERE id = last_insert_rowid()'))[0]
+  const members = getAllMembers()
+  members.forEach((m) => {
+    db.run(
+      'INSERT OR IGNORE INTO category_burden_ratios (category_id, member_id, ratio) VALUES (?, ?, 1)',
+      [newCategory.id, m.id]
+    )
+  })
   saveDb()
-  return toObjects(db.exec('SELECT * FROM categories WHERE id = last_insert_rowid()'))[0]
+  return newCategory
 }
 
 export function updateCategory(id, name) {
@@ -132,7 +161,40 @@ export function updateCategory(id, name) {
 }
 
 export function deleteCategory(id) {
+  db.run('DELETE FROM category_burden_ratios WHERE category_id = ?', [id])
   db.run('DELETE FROM categories WHERE id = ?', [id])
+  saveDb()
+}
+
+// ── Burden Ratios ─────────────────────────────────────────────────────────────
+
+export function getBurdenRatios(categoryId) {
+  const members = getAllMembers()
+  const existing = toObjects(
+    db.exec('SELECT member_id, ratio FROM category_burden_ratios WHERE category_id = ?', [
+      categoryId
+    ])
+  )
+  const ratioMap = {}
+  existing.forEach((r) => {
+    ratioMap[r.member_id] = r.ratio
+  })
+  return members.map((m) => ({
+    memberId: m.id,
+    memberName: m.name,
+    ratio: ratioMap[m.id] !== undefined ? ratioMap[m.id] : 1
+  }))
+}
+
+export function setBurdenRatios(categoryId, ratios) {
+  // ratios: [{memberId, ratio}]
+  ratios.forEach(({ memberId, ratio }) => {
+    db.run(
+      `INSERT INTO category_burden_ratios (category_id, member_id, ratio) VALUES (?, ?, ?)
+       ON CONFLICT(category_id, member_id) DO UPDATE SET ratio = excluded.ratio`,
+      [categoryId, memberId, ratio]
+    )
+  })
   saveDb()
 }
 

--- a/src/main/ipc.js
+++ b/src/main/ipc.js
@@ -8,6 +8,8 @@ import {
   createCategory,
   updateCategory,
   deleteCategory,
+  getBurdenRatios,
+  setBurdenRatios,
   getExpensesByMonth,
   createExpense,
   updateExpense,
@@ -27,6 +29,10 @@ export function registerIpcHandlers() {
   ipcMain.handle('categories:create', (_, name) => createCategory(name))
   ipcMain.handle('categories:update', (_, id, name) => updateCategory(id, name))
   ipcMain.handle('categories:delete', (_, id) => deleteCategory(id))
+  ipcMain.handle('categories:getBurdenRatios', (_, categoryId) => getBurdenRatios(categoryId))
+  ipcMain.handle('categories:setBurdenRatios', (_, categoryId, ratios) =>
+    setBurdenRatios(categoryId, ratios)
+  )
 
   // ── Expenses ───────────────────────────────────────────────────────────────
   ipcMain.handle('expenses:getByMonth', (_, year, month) => getExpensesByMonth(year, month))

--- a/src/preload/index.js
+++ b/src/preload/index.js
@@ -13,7 +13,10 @@ const api = {
     getAll: () => ipcRenderer.invoke('categories:getAll'),
     create: (name) => ipcRenderer.invoke('categories:create', name),
     update: (id, name) => ipcRenderer.invoke('categories:update', id, name),
-    delete: (id) => ipcRenderer.invoke('categories:delete', id)
+    delete: (id) => ipcRenderer.invoke('categories:delete', id),
+    getBurdenRatios: (categoryId) => ipcRenderer.invoke('categories:getBurdenRatios', categoryId),
+    setBurdenRatios: (categoryId, ratios) =>
+      ipcRenderer.invoke('categories:setBurdenRatios', categoryId, ratios)
   },
   expenses: {
     getByMonth: (year, month) => ipcRenderer.invoke('expenses:getByMonth', year, month),

--- a/src/renderer/src/components/CategoryManager.jsx
+++ b/src/renderer/src/components/CategoryManager.jsx
@@ -7,6 +7,12 @@ export default function CategoryManager() {
   const [editName, setEditName]     = useState('')
   const [loading, setLoading]       = useState(true)
 
+  // 負担割合編集用 state
+  const [ratioEditId, setRatioEditId]   = useState(null)  // 展開中カテゴリ ID
+  const [ratioValues, setRatioValues]   = useState({})    // { memberId: ratio }
+  const [ratioMembers, setRatioMembers] = useState([])    // [{memberId, memberName, ratio}]
+  const [ratioLoading, setRatioLoading] = useState(false)
+
   useEffect(() => { load() }, [])
 
   async function load() {
@@ -28,6 +34,8 @@ export default function CategoryManager() {
   function startEdit(c) {
     setEditId(c.id)
     setEditName(c.name)
+    // 別カテゴリの負担割合編集を閉じる
+    if (ratioEditId !== null) setRatioEditId(null)
   }
 
   async function handleUpdate(e) {
@@ -42,7 +50,39 @@ export default function CategoryManager() {
   async function handleDelete(id) {
     if (!confirm('このカテゴリを削除しますか？\n関連する支出のカテゴリが未設定になります。')) return
     await window.api.categories.delete(id)
+    if (ratioEditId === id) setRatioEditId(null)
     await load()
+  }
+
+  async function toggleRatioEdit(categoryId) {
+    if (ratioEditId === categoryId) {
+      setRatioEditId(null)
+      return
+    }
+    // 名前編集を閉じる
+    setEditId(null)
+    setRatioLoading(true)
+    setRatioEditId(categoryId)
+    const data = await window.api.categories.getBurdenRatios(categoryId)
+    const values = {}
+    data.forEach((r) => { values[r.memberId] = String(r.ratio) })
+    setRatioMembers(data)
+    setRatioValues(values)
+    setRatioLoading(false)
+  }
+
+  async function handleSaveRatios(e) {
+    e.preventDefault()
+    const ratios = ratioMembers.map((m) => ({
+      memberId: m.memberId,
+      ratio: Math.max(1, parseInt(ratioValues[m.memberId], 10) || 1)
+    }))
+    await window.api.categories.setBurdenRatios(ratioEditId, ratios)
+    setRatioEditId(null)
+  }
+
+  function handleRatioChange(memberId, value) {
+    setRatioValues((prev) => ({ ...prev, [memberId]: value }))
   }
 
   if (loading) return <div className="empty-state">読み込み中...</div>
@@ -57,48 +97,99 @@ export default function CategoryManager() {
         )}
 
         {categories.map(c => (
-          <div key={c.id} className="list-item">
-            {editId === c.id ? (
-              <form className="inline-form" onSubmit={handleUpdate}>
-                <input
-                  type="text"
-                  className="form-control"
-                  value={editName}
-                  onChange={e => setEditName(e.target.value)}
-                  autoFocus
-                />
-                <button type="submit" className="btn btn-primary btn-sm">保存</button>
-                <button
-                  type="button"
-                  className="btn btn-secondary btn-sm"
-                  onClick={() => setEditId(null)}
-                >
-                  キャンセル
-                </button>
-              </form>
-            ) : (
-              <>
-                <span className="list-item-name">
-                  <span className="badge badge-blue" style={{ marginRight: 8 }}>{c.name}</span>
-                </span>
-                <div className="actions">
+          <div key={c.id}>
+            <div className="list-item">
+              {editId === c.id ? (
+                <form className="inline-form" onSubmit={handleUpdate}>
+                  <input
+                    type="text"
+                    className="form-control"
+                    value={editName}
+                    onChange={e => setEditName(e.target.value)}
+                    autoFocus
+                  />
+                  <button type="submit" className="btn btn-primary btn-sm">保存</button>
                   <button
-                    className="btn-icon"
-                    onClick={() => startEdit(c)}
-                    title="編集"
+                    type="button"
+                    className="btn btn-secondary btn-sm"
+                    onClick={() => setEditId(null)}
                   >
-                    ✎
+                    キャンセル
                   </button>
-                  <button
-                    className="btn-icon"
-                    onClick={() => handleDelete(c.id)}
-                    title="削除"
-                    style={{ color: '#dc2626' }}
-                  >
-                    ✕
-                  </button>
+                </form>
+              ) : (
+                <>
+                  <span className="list-item-name">
+                    <span className="badge badge-blue" style={{ marginRight: 8 }}>{c.name}</span>
+                  </span>
+                  <div className="actions">
+                    <button
+                      className="btn-icon"
+                      onClick={() => toggleRatioEdit(c.id)}
+                      title="負担割合"
+                      style={{ color: ratioEditId === c.id ? '#2563eb' : undefined }}
+                    >
+                      ⚖
+                    </button>
+                    <button
+                      className="btn-icon"
+                      onClick={() => startEdit(c)}
+                      title="編集"
+                    >
+                      ✎
+                    </button>
+                    <button
+                      className="btn-icon"
+                      onClick={() => handleDelete(c.id)}
+                      title="削除"
+                      style={{ color: '#dc2626' }}
+                    >
+                      ✕
+                    </button>
+                  </div>
+                </>
+              )}
+            </div>
+
+            {ratioEditId === c.id && (
+              <div style={{ padding: '12px 16px', background: '#f8fafc', borderTop: '1px solid #e2e8f0' }}>
+                <div style={{ fontSize: 13, fontWeight: 600, marginBottom: 10, color: '#475569' }}>
+                  負担割合（整数比）
                 </div>
-              </>
+                {ratioLoading ? (
+                  <div style={{ fontSize: 13, color: '#94a3b8' }}>読み込み中...</div>
+                ) : ratioMembers.length === 0 ? (
+                  <div style={{ fontSize: 13, color: '#94a3b8' }}>メンバーが登録されていません</div>
+                ) : (
+                  <form onSubmit={handleSaveRatios}>
+                    <div style={{ display: 'flex', flexDirection: 'column', gap: 8, marginBottom: 12 }}>
+                      {ratioMembers.map((m) => (
+                        <div key={m.memberId} style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+                          <span style={{ minWidth: 80, fontSize: 14 }}>{m.memberName}</span>
+                          <input
+                            type="number"
+                            min={1}
+                            className="form-control"
+                            style={{ width: 80 }}
+                            value={ratioValues[m.memberId] ?? '1'}
+                            onChange={(e) => handleRatioChange(m.memberId, e.target.value)}
+                          />
+                        </div>
+                      ))}
+                    </div>
+                    <div style={{ display: 'flex', gap: 8 }}>
+                      <button type="submit" className="btn btn-primary btn-sm">保存</button>
+                      <button
+                        type="button"
+                        className="btn btn-secondary btn-sm"
+                        onClick={() => setRatioEditId(null)}
+                      >
+                        キャンセル
+                      </button>
+                    </div>
+                  </form>
+                )}
+              </div>
             )}
           </div>
         ))}


### PR DESCRIPTION
- category_burden_ratios テーブルを追加（category_id, member_id, ratio INTEGER）
- メンバー・カテゴリ追加時にデフォルト ratio=1 を自動登録
- メンバー・カテゴリ削除時に関連する ratio レコードを削除
- IPC ハンドラー / preload API に getBurdenRatios / setBurdenRatios を追加
- CategoryManager UI に ⚖ ボタンから開く負担割合編集パネルを追加

closes #2

https://claude.ai/code/session_01S4L6XmyNehpe7xBSuxM33Z